### PR TITLE
Fix return value and typo

### DIFF
--- a/aws-agent-commerce-project/BytesCommerce/actiongroup/BytesCommerceFunction.py
+++ b/aws-agent-commerce-project/BytesCommerce/actiongroup/BytesCommerceFunction.py
@@ -35,7 +35,7 @@ def lambda_handler(event, context):
         # Product Restock Order creation code would go here.
         response_data = {"status": "Success"}
     else:
-        response_data = {"message": "Unknwon API Path"}
+        response_data = {"message": "Unknown API Path"}
         
 
     #response_body = {

--- a/aws-agent-commerce-project/util.py
+++ b/aws-agent-commerce-project/util.py
@@ -91,4 +91,4 @@ def invoke_agent(agentId: str, agentAliasId: str, inputText: str, sessionId: str
                                 print(f"  PII Detected: {pii['type']} (Action: {pii['action']})")
 
     print(f"\n\nSession ID: {response.get('sessionId')}")
-    return
+    return agent_response


### PR DESCRIPTION
## Summary
- return the captured agent output in `util.invoke_agent`
- fix typo in bytes commerce lambda

## Testing
- `python -m py_compile aws-agent-commerce-project/util.py aws-agent-commerce-project/BytesCommerce/actiongroup/BytesCommerceFunction.py`

------
https://chatgpt.com/codex/tasks/task_e_6848ed876f608323a857e17509767eb3